### PR TITLE
Add Tmp Messages

### DIFF
--- a/src/completion/client.rs
+++ b/src/completion/client.rs
@@ -27,7 +27,7 @@ pub enum CompletionOption {
 pub struct Groq {
     api_key: String,
     messages: Vec<Message>,
-    tmp_messages: Vec<Message>,
+    disposable_msgs: Vec<Message>,
     client: reqwest::Client,
 }
 
@@ -44,7 +44,7 @@ impl Groq {
         Self {
             api_key: api_key.into(),
             client: reqwest::Client::new(),
-            tmp_messages: Vec::new(),
+            disposable_msgs: Vec::new(),
             messages: Vec::new(),
         }
     }
@@ -73,34 +73,34 @@ impl Groq {
     /// # Note
     /// Fucntion is created for internal use and is not recomended for external use.
     pub fn clear_tmp_messages_override(&mut self) {
-        self.tmp_messages.clear();
+        self.disposable_msgs.clear();
     }
 
     pub fn add_tmp_messages(mut self, msgs: Vec<Message>) -> Self {
-        self.tmp_messages.extend(msgs);
+        self.disposable_msgs.extend(msgs);
         self
     }
 
     pub fn add_tmp_message(mut self, msg: Message) -> Self {
-        self.tmp_messages.push(msg);
+        self.disposable_msgs.push(msg);
         self
     }
 
     fn get_tmp_request_messages(&self) -> Option<Vec<Message>> {
-        if self.tmp_messages.is_empty() {
+        if self.disposable_msgs.is_empty() {
             None
         } else {
-            Some(self.tmp_messages.clone())
+            Some(self.disposable_msgs.clone())
         }
     }
 
     /// Outputs the request messages that should be passed onto the request.
     /// Utility function created for easier logic internally.
     fn get_all_request_messages(&self) -> Vec<Message> {
-        if self.tmp_messages.is_empty() {
+        if self.disposable_msgs.is_empty() {
             self.messages.clone()
         } else {
-            return vec![self.tmp_messages.clone(), self.messages.clone()].concat();
+            return vec![self.disposable_msgs.clone(), self.messages.clone()].concat();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!     let api_key = env!("GROQ_API_KEY");
 //!
 //!     let client = Groq::new(api_key);
-//!     let client = client.add_messages(messages);
+//!     let mut client = client.add_messages(messages);
 //!
 //!     let res = client.create(request).await;
 //!     assert!(res.is_ok());
@@ -50,7 +50,7 @@
 //!     let api_key = env!("GROQ_API_KEY");
 //!
 //!     let client = Groq::new(api_key);
-//!     let client = client.add_messages(messages);
+//!     let mut client = client.add_messages(messages);
 //!
 //!     let res = client.create(request).await;
 //!     assert!(res.is_ok());
@@ -73,7 +73,7 @@
 //!     let api_key = "";
 //!
 //!     let client = Groq::new(api_key);
-//!     let client = client.add_messages(messages);
+//!     let mut client = client.add_messages(messages);
 //!
 //!     let res = client.create(request).await;
 //!     assert!(res.is_err());


### PR DESCRIPTION
When working with configs containing stationary messages, it is impossible (on the current version of this library) to have some "global" (never changing) messages and some "tmp" (changing) messages that can change from request to request.

----

Example: 

You want to give the ai some context to how to react to your messages and then want to send one message. However, at the moment, the only functionality is "add message" and "remove message". To do the task mentioned in the previous sentence, you would have to keep a variable named "stationary_messages". When prompting, you would have to do 
`<instance_name>.clear_messages().add_messages(stationary_messages).add_message(message).`

---

In my pull request I created a "tmp_messages" that are cleared upon each request (in create_non_stream_completion()) via a function "get_request_messages_with_tmp_clear()" which gets all of the messages 
(via `vec![self.tmp_messages.clone(), self.messages.clone()].concat()`) 
and then clears all of the tmp messages that the user added.

---

**NOTE:** I am not sure in which order the tmp_messages and the messages should be in. In this pull request I am assuming that the ai will take the first message as the actual main prompt and respond to **it**.

**NOTE 2:** Some code in terms of client being mutable had to be modified so now you would have to do 

```
let mut client = client.add_messages(messages);
let res = client.create(request).await;
```

instead of 

```
let client = client.add_messages(messages);
let res = client.create(request).await;
```

when creating/sending reqs.

--- 
Now something like this will be possible: 

```
let messages = vec![Message::SystemMessage {
    content: Some("I am a system message".to_string()),
    name: None,
    role: Some("system".to_string()),
    tool_call_id: None,
}];

let request = builder::RequestBuilder::new("mixtral-8x7b-32768".to_string());
let api_key = env!("GROQ_API_KEY");

let client = Groq::new(api_key);
let mut client = client.add_messages(messages);

let requests_to_send = vec![
    Message::UserMessage {
        role: Some("user".to_string()),
        content: Some("Explain the importance of fast language models".to_string()),
        name: None,
        tool_call_id: None,
    },
    Message::UserMessage {
        role: Some("user".to_string()),
        content: Some(
            "Explain the importance of fast language models message 2".to_string(),
        ),
        name: None,
        tool_call_id: None,
    },
];

for msg in requests_to_send {
    client.add_tmp_message(msg);
    let res = client.create(request).await;
    ... your later logic here ...
}
```